### PR TITLE
I've added a document with notes on my analysis of the codebase.

### DIFF
--- a/people-gpt-champion/docs/codebase-analysis-notes.md
+++ b/people-gpt-champion/docs/codebase-analysis-notes.md
@@ -1,0 +1,169 @@
+# Codebase Analysis Notes
+
+## 1. `lib/candidateProcessor.ts`
+
+*   **File Purpose**: This file defines a module `candidateProcessor.ts` containing a function `processInternalCandidateData`. This function is designed to take raw candidate data, validate its schema using Zod, perform transformations (e.g., generating an ID, deriving a job title from skills), and then validate the output schema.
+*   **Current Status**: As of the latest review (2024-03-07), this module appears to be **unused** within the `people-gpt-champion` application.
+*   **Investigation**:
+    *   Checked `pages/api/parse-resume.ts` (resume ingestion pipeline).
+    *   Checked API routes under `pages/api/candidate/`.
+    *   Checked utility scripts in `scripts/`.
+    *   Checked App Router API routes under `app/api/`.
+    *   No imports or usages of `processInternalCandidateData` were found in these likely locations or through general codebase exploration.
+*   **Recommendations**:
+    *   **Verify Obsolescence**: Double-check if this module was part of a deprecated feature or if its integration was planned but not completed.
+    *   **Action**:
+        *   If confirmed obsolete and not planned for future use, consider removing the file (`lib/candidateProcessor.ts`) and its associated test file (`lib/__tests__/candidateProcessor.test.ts`) to simplify the codebase.
+        *   If it's intended for a future feature, create a development ticket to track its integration. Document its intended use case clearly.
+
+## 2. Fairness Dashboard Data Source (`pages/api/fairness-metrics.ts`)
+
+*   **API Endpoint**: `pages/api/fairness-metrics.ts`
+*   **Functionality**: This API route is intended to supply data for a fairness dashboard, likely displaying metrics such as demographic parity and equal opportunity over time.
+*   **Current Status**: The endpoint currently returns **static, mock data**.
+    *   The file content explicitly states: `// MOCK DATA: In a real system, this data would be fetched from a database...`
+    *   It also contains a `// TODO: Implement actual data fetching and aggregation logic here.`
+*   **Observations**:
+    *   The structure of the mock data includes `demographicParity`, `equalOpportunity`, `timestamps`, and conceptual `alertThresholds`.
+    *   This indicates a planned feature for monitoring fairness, which is not yet functionally implemented on the backend data sourcing side.
+*   **Recommendations**:
+    *   **Acknowledge Current State**: Ensure any documentation or user guides for the Fairness Dashboard clearly state that it's operating with mock data.
+    *   **Prioritize Backend Development**: If Fairness Dashboard is a priority, allocate resources to implement the backend logic mentioned in the `TODO`. This involves:
+        *   Defining how and where fairness metrics will be computed (e.g., as part of a data pipeline, scheduled jobs).
+        *   Designing the database schema to store these metrics.
+        *   Implementing the data fetching and aggregation logic within the API.
+    *   **Iterative Approach**: Consider an iterative approach, perhaps starting with a few key metrics and expanding over time.
+
+## 3. `ChatMessageDisplay` and `ChatInput` on `app/page.tsx`
+
+*   **Components**: `components/ChatMessageDisplay.tsx` and `components/ChatInput.tsx`.
+*   **Usage Location**: These components are used on the main page `app/page.tsx` within a section titled "Chat Example (New)".
+*   **Functionality**:
+    *   `ChatInput` captures user text input.
+    *   `ChatMessageDisplay` renders a list of messages.
+    *   On `app/page.tsx`, they are wired together via `handleSendMessage` which adds the user's message to a state variable (`chatMessages`) and then simulates an AI response with a `setTimeout` function.
+    *   ```typescript
+      // Excerpt from app/page.tsx
+      const handleSendMessage = (text: string) => {
+        const newUserMessage: Message = { id: Date.now().toString(), text, sender: 'user', timestamp: new Date() };
+        setChatMessages(prev => [...prev, newUserMessage]);
+        // Dummy AI response
+        setTimeout(() => {
+          const aiResponse: Message = { id: (Date.now() + 1).toString(), text: `AI received: "${text}"`, sender: 'ai', timestamp: new Date() };
+          setChatMessages(prev => [...prev, aiResponse]);
+        }, 500);
+      };
+      ```
+*   **Clarification on Issue Statement**:
+    *   The original issue mentioned: "While ChatInput is used for search, the display component's full utility for a back-and-forth conversation isn't fully realized..."
+    *   **Correction**: The `ChatInput` component within this "Chat Example (New)" section is **not** used for the primary candidate search functionality on `app/page.tsx`. Candidate search is handled by `SearchInput` components (both a legacy and a new version).
+    *   The `ChatMessageDisplay` and `ChatInput` setup is a **standalone demonstration of a chat interface** and is not integrated with search results or a live conversational AI backend.
+*   **Current State**:
+    *   The components are set up for a potential chat feature, but it's currently a mock/demonstration.
+    *   The "full utility for a back-and-forth conversation" is not realized because it lacks backend integration for genuine AI responses or connection to application data/actions.
+*   **Recommendations**:
+    *   **Update Documentation**: Ensure any internal or user-facing documentation accurately describes this chat section as an example or a placeholder for a future feature.
+    *   **Feature Development**: If a functional chat for conversational search or other purposes is desired, this would require significant development:
+        *   Defining the chat's purpose and how it should interact with search, candidate data, etc.
+        *   Integrating with a conversational AI platform or building custom NLP logic.
+        *   Managing chat state and history more robustly.
+    *   **Avoid Confusion**: If this example is not planned for further development, consider labeling it more explicitly as a "UI Demo" on the page to avoid confusion with active search features.
+
+## 4. Pinecone Vector Upsert Gap
+
+*   **Context**: The application uses vector embeddings for semantic search. Pinecone is the vector database intended for storing and querying these embeddings.
+*   **Embedding Generation**:
+    *   `pages/api/parse-resume.ts` is responsible for processing uploaded resumes.
+    *   This API route successfully generates embeddings from resume text using an OpenAI service (`getEmbeddingBreaker`).
+    *   ```typescript
+      // Excerpt from pages/api/parse-resume.ts
+      const embeddingResponse = await getEmbeddingBreaker.fire(rawResumeText);
+      // ...
+      embeddingArray = embeddingResponse.data[0].embedding;
+      const embeddingBuffer = Buffer.from(new Float32Array(embeddingArray).buffer);
+      ```
+*   **Embedding Storage (Current)**:
+    *   The generated `embeddingBuffer` is **stored in the main relational database (PostgreSQL via Prisma)** in the `vectorEmbedding` field of the `Candidate` table.
+    *   ```typescript
+      // Excerpt from pages/api/parse-resume.ts
+      const newCandidate = await prisma.candidate.create({
+        data: {
+          // ... other fields
+          vectorEmbedding: embeddingBuffer,
+        },
+      });
+      ```
+    *   There is **no call to `pinecone.upsert()`** or any other function to send these embeddings to the Pinecone vector database within `pages/api/parse-resume.ts`.
+*   **Pinecone Usage (Querying)**:
+    *   The search API endpoint `pages/api/search.ts` **correctly uses Pinecone for querying**.
+    *   It takes a search query, generates an embedding for it, and then queries a Pinecone index using `queryPineconeIndex` from `lib/pinecone.ts`.
+    *   `lib/pinecone.ts` is configured for initializing a Pinecone client and querying an index. It does **not** contain functions for upserting data.
+*   **Identified Gap**:
+    *   There is a critical missing step in the data pipeline: **embeddings generated from new resumes are not being upserted into the Pinecone index.**
+    *   This means that new candidates processed by `parse-resume.ts` will not be discoverable via the semantic search functionality that relies on Pinecone. The search will only operate on embeddings that were somehow previously populated in Pinecone.
+*   **Recommendations**:
+    *   **High Priority Fix**: This is a significant gap affecting a core feature (semantic search for new candidates). Implementing the Pinecone upsert process should be a high priority.
+    *   **Implementation Strategy**:
+        *   Modify `pages/api/parse-resume.ts`: After successfully saving the candidate to Prisma and obtaining the candidate ID and embedding, add logic to call a Pinecone upsert function.
+        *   The upsert operation should store the vector embedding along with the candidate's ID (e.g., `prismaCandidate.id`) as metadata in Pinecone. This ID is crucial for linking Pinecone query results back to the full candidate data in Prisma.
+        *   Consider adding upsert logic to `lib/pinecone.ts` (e.g., an `upsertToPineconeIndex` function) with appropriate error handling and circuit breaker patterns, similar to `queryPineconeIndex`.
+    *   **Batching**: For the batch resume upload feature in `parse-resume.ts`, consider if Pinecone upserts should also be batched for efficiency.
+    *   **Data Consistency**: Think about error handling for Pinecone upserts. What happens if the Prisma save succeeds but the Pinecone upsert fails? Implement retry mechanisms or a way to flag candidates whose embeddings failed to sync.
+    *   **Backfill Strategy**: Develop a strategy or script to backfill embeddings into Pinecone for existing candidates in the Prisma database who are missing from Pinecone.
+
+## 5. Root Configuration Files (`.gitignore`, `package.json`)
+
+*   **Context**: The repository contains `.gitignore` and `package.json` files at the root level, as well as within the `people-gpt-champion/` subdirectory (which houses the main Next.js application). This has led to some ambiguity.
+
+*   **`package.json` Files**:
+    *   **Root `package.json`**:
+        *   Content:
+            ```json
+            {
+              "scripts": {
+                "msw:init": "npx msw init public/ --save"
+              },
+              "devDependencies": {
+                "msw": "^2.8.7"
+              },
+              "msw": {
+                "workerDirectory": [
+                  "public"
+                ]
+              }
+            }
+            ```
+        *   Purpose: This file is very minimal and appears to be solely for managing `msw` (Mock Service Worker). The `msw:init` script is intended to initialize MSW.
+    *   **`people-gpt-champion/package.json`**:
+        *   Purpose: This is the primary, comprehensive `package.json` for the Next.js application. It includes all project dependencies, build scripts, linting, testing configurations, etc.
+
+*   **`.gitignore` Files**:
+    *   **Root `.gitignore`**:
+        *   Content includes general ignores like `node_modules`, build artifacts (`.next/`, `out/`), IDE files, and importantly, `public/mockServiceWorker.js`.
+    *   **`people-gpt-champion/.gitignore`**:
+        *   More specific to the Next.js application (e.g., ignores `/lib/generated/prisma`).
+        *   It does **not** explicitly ignore `public/mockServiceWorker.js` within the `people-gpt-champion/public/` directory.
+
+*   **Analysis of Ambiguity & MSW Setup**:
+    *   **Primary Application**: The main application logic and its dependencies are entirely managed within `people-gpt-champion/`.
+    *   **MSW Initialization**:
+        *   The `msw:init` script in the root `package.json` (`npx msw init public/ --save`) is problematic. If run from the root, it would attempt to create `public/mockServiceWorker.js` in the *root* directory (if a `public/` folder existed there).
+        *   It's highly probable this script is intended for the `people-gpt-champion` application's `public` directory.
+    *   **MSW `workerDirectory`**: The `msw.workerDirectory` in the root `package.json` is `["public"]`. This also likely refers to `people-gpt-champion/public/`.
+    *   **`.gitignore` Conflict for MSW**:
+        *   The root `.gitignore` ignores `public/mockServiceWorker.js`.
+        *   The `people-gpt-champion/.gitignore` does *not* ignore `public/mockServiceWorker.js` (meaning it would be tracked if it existed in `people-gpt-champion/public/`).
+        *   MSW documentation generally recommends that the generated `mockServiceWorker.js` file *should* be committed to version control.
+
+*   **Recommendations**:
+    *   **Consolidate MSW Management**:
+        *   Consider moving the MSW dependency (`msw`) and the `msw:init` script into the `people-gpt-champion/package.json`. This centralizes all application-specific tooling.
+        *   If moved, the `msw:init` script in `people-gpt-champion/package.json` would simply be `msw init public/ --save` (ran from within `people-gpt-champion/`).
+    *   **Clarify MSW `workerDirectory`**: If MSW setup is moved into the app, the `msw.workerDirectory` in `people-gpt-champion/package.json` should be `["public"]` (relative to `people-gpt-champion/`).
+    *   **`.gitignore` for MSW**:
+        *   The `people-gpt-champion/.gitignore` currently allows `public/mockServiceWorker.js` to be tracked, which aligns with MSW best practices. This is good.
+        *   The entry `public/mockServiceWorker.js` in the root `.gitignore` would become irrelevant if MSW is managed within the app, or it should be removed if the root `package.json` is kept and the script fixed to target the app's public dir.
+    *   **Root Files Purpose**:
+        *   If the root `package.json` has no other purpose beyond MSW (which should ideally be moved), question its necessity. If it's for a broader monorepo structure that isn't fully implemented or is now deprecated, consider removing it to reduce complexity.
+        *   The root `.gitignore` can be simplified if the application is solely contained in `people-gpt-champion/`. If other top-level directories or files are expected, it can remain but should be reviewed for relevance.
+    *   **Decision Point**: Decide on the canonical location for MSW setup. The most straightforward approach for a single primary application is to manage it entirely within `people-gpt-champion/`.


### PR DESCRIPTION
This document summarizes findings related to several areas of the codebase:

- Status of `lib/candidateProcessor.ts` (currently unused).
- Static nature of data from `/api/fairness-metrics`.
- Usage and functionality of `ChatMessageDisplay` and `ChatInput` on `app/page.tsx`.
- The gap in Pinecone integration (embeddings generated but not upserted from resume parsing).
- Ambiguities and recommendations for root `.gitignore` and `package.json` files, particularly concerning MSW setup.

These notes are intended to clarify potential nuances and guide your future development efforts.